### PR TITLE
Add authentication and account views with routing

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,8 +44,28 @@ const router = createRouter({
       name: 'roulette',
       component: GameCategoryView,
       props: { title: 'Рулетка', description: 'Всі види рулетки: Європейська, Американська та інші.' }
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('../views/LoginView.vue')
+    },
+    {
+      path: '/register',
+      name: 'register',
+      component: () => import('../views/RegisterView.vue')
+    },
+    {
+      path: '/password-recovery',
+      name: 'password-recovery',
+      component: () => import('../views/PasswordRecoveryView.vue')
+    },
+    {
+      path: '/account',
+      name: 'account',
+      component: () => import('../views/AccountView.vue')
     }
   ]
 })
-
+ 
 export default router

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,0 +1,31 @@
+<script setup>
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="page-header">
+        <h1>Аккаунт</h1>
+        <p>Управляйте данными своего профиля.</p>
+      </div>
+      <div class="account-details">
+        <p><strong>Имя пользователя:</strong> demo</p>
+        <p><strong>Email:</strong> demo@example.com</p>
+      </div>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.page-header { margin-bottom: 32px; }
+.account-details {
+  background: var(--card);
+  padding: 24px;
+  border-radius: var(--radius);
+}
+.account-details p { margin-bottom: 8px; }
+</style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,53 @@
+<script setup>
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="auth-form">
+        <img class="auth-logo" src="/img/loginlogo.png" alt="Login" />
+        <h1>Вход</h1>
+        <form>
+          <input type="email" placeholder="Email" required />
+          <input type="password" placeholder="Пароль" required />
+          <button type="submit" class="btn btn-lg">Войти</button>
+        </form>
+        <router-link to="/password-recovery" class="link">Забыли пароль?</router-link>
+        <router-link to="/register" class="link">Регистрация</router-link>
+      </div>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.auth-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 32px;
+  background: var(--card);
+  border-radius: var(--radius);
+  text-align: center;
+}
+.auth-logo {
+  width: 120px;
+  margin: 0 auto 24px;
+}
+.auth-form input {
+  width: 100%;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background-color: #1d1f26;
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+}
+.auth-form .link {
+  display: block;
+  margin-top: 8px;
+  color: var(--accent);
+}
+</style>

--- a/src/views/PasswordRecoveryView.vue
+++ b/src/views/PasswordRecoveryView.vue
@@ -1,0 +1,51 @@
+<script setup>
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="auth-form">
+        <img class="auth-logo" src="/img/passrec.png" alt="Password recovery" />
+        <h1>Восстановление пароля</h1>
+        <form>
+          <input type="email" placeholder="Email" required />
+          <button type="submit" class="btn btn-lg">Отправить ссылку</button>
+        </form>
+        <router-link to="/login" class="link">Назад ко входу</router-link>
+      </div>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.auth-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 32px;
+  background: var(--card);
+  border-radius: var(--radius);
+  text-align: center;
+}
+.auth-logo {
+  width: 120px;
+  margin: 0 auto 24px;
+}
+.auth-form input {
+  width: 100%;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background-color: #1d1f26;
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+}
+.auth-form .link {
+  display: block;
+  margin-top: 8px;
+  color: var(--accent);
+}
+</style>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -1,0 +1,54 @@
+<script setup>
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="auth-form">
+        <img class="auth-logo" src="/img/lodgincard.png" alt="Register" />
+        <h1>Регистрация</h1>
+        <form>
+          <input type="text" placeholder="Имя пользователя" required />
+          <input type="email" placeholder="Email" required />
+          <input type="password" placeholder="Пароль" required />
+          <input type="password" placeholder="Подтвердите пароль" required />
+          <button type="submit" class="btn btn-lg">Создать аккаунт</button>
+        </form>
+        <router-link to="/login" class="link">Уже есть аккаунт? Войти</router-link>
+      </div>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.auth-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 32px;
+  background: var(--card);
+  border-radius: var(--radius);
+  text-align: center;
+}
+.auth-logo {
+  width: 120px;
+  margin: 0 auto 24px;
+}
+.auth-form input {
+  width: 100%;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background-color: #1d1f26;
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+}
+.auth-form .link {
+  display: block;
+  margin-top: 8px;
+  color: var(--accent);
+}
+</style>


### PR DESCRIPTION
## Summary
- add LoginView, RegisterView, PasswordRecoveryView, and AccountView components using shared sidebars and auth form styling
- register routes for login, register, password recovery, and account pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acab4ea9d48320be4da84379a0f888