### PR TITLE
feat: add basic auth composable

### DIFF
--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -1,0 +1,50 @@
+import { ref } from 'vue'
+
+const isLoggedIn = ref(false)
+const user = ref(null)
+
+function init() {
+  const storedUser = localStorage.getItem('authUser')
+  const storedLoggedIn = localStorage.getItem('isLoggedIn')
+  if (storedUser && storedLoggedIn === 'true') {
+    user.value = JSON.parse(storedUser)
+    isLoggedIn.value = true
+  }
+}
+
+init()
+
+function register(credentials) {
+  localStorage.setItem('authUser', JSON.stringify(credentials))
+  localStorage.setItem('isLoggedIn', 'true')
+  user.value = credentials
+  isLoggedIn.value = true
+}
+
+function login(credentials) {
+  const stored = localStorage.getItem('authUser')
+  if (!stored) return false
+  const storedUser = JSON.parse(stored)
+  const valid =
+    credentials.username === storedUser.username &&
+    credentials.password === storedUser.password
+  if (valid) {
+    localStorage.setItem('isLoggedIn', 'true')
+    user.value = storedUser
+    isLoggedIn.value = true
+    return true
+  }
+  isLoggedIn.value = false
+  return false
+}
+
+function logout() {
+  localStorage.setItem('isLoggedIn', 'false')
+  user.value = null
+  isLoggedIn.value = false
+}
+
+export default function useAuth() {
+  return { isLoggedIn, user, login, register, logout }
+}
+


### PR DESCRIPTION
## Summary
- add `useAuth` composable handling login state and credential storage
- persist auth state via localStorage for reloads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acab540d60832085d1e4acb36e26eb