### PR TITLE
Add basic auth views with confirmation messages

### DIFF
--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+
+const storedUser = ref(JSON.parse(localStorage.getItem('user')) || null)
+
+export function useAuth() {
+  const user = storedUser
+  const register = async ({ email, password }) => {
+    const newUser = { email, password }
+    localStorage.setItem('user', JSON.stringify(newUser))
+    user.value = { email }
+    return true
+  }
+  const login = async ({ email, password }) => {
+    const saved = JSON.parse(localStorage.getItem('user'))
+    if (saved && saved.email === email && saved.password === password) {
+      user.value = { email }
+      return true
+    }
+    throw new Error('Неверные учетные данные')
+  }
+  return { user, register, login }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,21 @@ const router = createRouter({
       name: 'roulette',
       component: GameCategoryView,
       props: { title: 'Рулетка', description: 'Всі види рулетки: Європейська, Американська та інші.' }
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('../views/LoginView.vue')
+    },
+    {
+      path: '/register',
+      name: 'register',
+      component: () => import('../views/RegisterView.vue')
+    },
+    {
+      path: '/account',
+      name: 'account',
+      component: () => import('../views/AccountView.vue')
     }
   ]
 })

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { useAuth } from '../composables/useAuth'
+
+const { user } = useAuth()
+</script>
+
+<template>
+  <div class="account">
+    <h1>Личный кабинет</h1>
+    <p v-if="user">Добро пожаловать, {{ user.email }}!</p>
+    <p v-else>Нет данных пользователя.</p>
+  </div>
+</template>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuth } from '../composables/useAuth'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+
+const router = useRouter()
+const { login } = useAuth()
+
+const handleSubmit = async () => {
+  error.value = ''
+  try {
+    await login({ email: email.value, password: password.value })
+    alert('Подтверждение')
+    router.push('/account')
+  } catch (e) {
+    error.value = 'Неверный логин или пароль'
+  }
+}
+</script>
+
+<template>
+  <div class="login">
+    <h1>Войти</h1>
+    <form @submit.prevent="handleSubmit">
+      <div>
+        <label for="email">Email</label>
+        <input id="email" v-model="email" type="email" required />
+      </div>
+      <div>
+        <label for="password">Пароль</label>
+        <input id="password" v-model="password" type="password" required />
+      </div>
+      <button type="submit">Войти</button>
+      <p v-if="error" class="error">{{ error }}</p>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.error {
+  color: red;
+}
+</style>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuth } from '../composables/useAuth'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+
+const router = useRouter()
+const { register } = useAuth()
+
+const handleSubmit = async () => {
+  error.value = ''
+  try {
+    await register({ email: email.value, password: password.value })
+    alert('Подтверждение')
+    router.push('/account')
+  } catch (e) {
+    error.value = 'Ошибка регистрации'
+  }
+}
+</script>
+
+<template>
+  <div class="register">
+    <h1>Регистрация</h1>
+    <form @submit.prevent="handleSubmit">
+      <div>
+        <label for="email">Email</label>
+        <input id="email" v-model="email" type="email" required />
+      </div>
+      <div>
+        <label for="password">Пароль</label>
+        <input id="password" v-model="password" type="password" required />
+      </div>
+      <button type="submit">Зарегистрироваться</button>
+      <p v-if="error" class="error">{{ error }}</p>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.error {
+  color: red;
+}
+</style>


### PR DESCRIPTION
## Summary
- add simple `useAuth` composable for login and registration
- create login, registration, and account views with confirmation alerts
- wire new views into router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acab561f8883208cbf9bba827e347c