### PR TITLE
feat: add account view with logout

### DIFF
--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -1,0 +1,24 @@
+import { ref } from 'vue';
+
+// Simple auth composable using localStorage to persist user session.
+// In a real project this could be replaced with a proper auth provider.
+const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
+const user = ref(stored ? JSON.parse(stored) : null);
+
+export function useAuth() {
+  const login = (email) => {
+    user.value = { email };
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('user', JSON.stringify(user.value));
+    }
+  };
+
+  const logout = () => {
+    user.value = null;
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('user');
+    }
+  };
+
+  return { user, login, logout };
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,11 +1,11 @@
-import { createRouter, createWebHistory } from 'vue-router'
-import HomeView from '../views/HomeView.vue'
-import GameCategoryView from '../views/GameCategoryView.vue'
+import { createRouter, createWebHistory } from 'vue-router';
+import HomeView from '../views/HomeView.vue';
+import GameCategoryView from '../views/GameCategoryView.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   scrollBehavior(to, from, savedPosition) {
-    return { top: 0 }
+    return { top: 0 };
   },
   routes: [
     {
@@ -44,8 +44,13 @@ const router = createRouter({
       name: 'roulette',
       component: GameCategoryView,
       props: { title: 'Рулетка', description: 'Всі види рулетки: Європейська, Американська та інші.' }
+    },
+    {
+      path: '/account',
+      name: 'account',
+      component: () => import('../views/AccountView.vue')
     }
   ]
-})
+});
 
-export default router
+export default router;

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { useRouter } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
+
+const router = useRouter();
+const { user, logout } = useAuth();
+
+function handleLogout() {
+  logout();
+  router.push('/');
+}
+</script>
+
+<template>
+  <div class="account container">
+    <h1 class="account-title">Личный кабинет</h1>
+
+    <div class="account-info card">
+      <p class="email">Вы вошли как <strong>{{ user?.email }}</strong></p>
+      <button class="btn btn-lg logout-btn" @click="handleLogout">Выйти</button>
+    </div>
+
+    <section class="widgets">
+      <div class="widget card">
+        <h2>Недавние игры</h2>
+        <p>Здесь появятся ваши последние запуски слотов.</p>
+      </div>
+      <div class="widget card">
+        <h2>Бонусы</h2>
+        <p>Следите за прогрессом и активируйте бонусы.</p>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.account {
+  padding: 48px 0;
+}
+.account-title {
+  font-size: 2.5rem;
+  text-align: center;
+  margin-bottom: 32px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+.account-info {
+  text-align: center;
+  margin-bottom: 40px;
+}
+.email {
+  font-size: 1.25rem;
+  margin-bottom: 20px;
+}
+.logout-btn {
+  width: 100%;
+}
+.widgets {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.widget h2 {
+  margin-bottom: 12px;
+}
+.widget p {
+  color: var(--muted);
+}
+</style>


### PR DESCRIPTION
## Summary
- add localStorage-based auth composable
- create account dashboard with logout button and placeholder widgets
- register account route

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acab5753188320b94b36108e1f8d0b