### PR TITLE
Add responsive breakpoints to views

### DIFF
--- a/src/views/GameCategoryView.vue
+++ b/src/views/GameCategoryView.vue
@@ -23,9 +23,14 @@ defineProps({
     <RightSidebar />
   </div>
 </template>
-
 <style scoped>
 .page-header { margin-bottom: 32px; }
 .page-header h1 { font-size: 2.5rem; margin-bottom: 8px; }
 .page-header p { color: var(--muted); }
+@media (max-width: 768px) {
+  .page-header h1 { font-size: 2rem; }
+}
+@media (max-width: 480px) {
+  .page-header h1 { font-size: 1.75rem; }
+}
 </style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -41,3 +41,20 @@ import { popularGames } from '@/data/mockData.js'; // Використовуєм
     <RightSidebar />
   </div>
 </template>
+<style scoped>
+@media (max-width: 768px) {
+  .promo {
+    flex-direction: column;
+    text-align: center;
+  }
+  .promo .btn {
+    width: 100%;
+  }
+}
+@media (max-width: 480px) {
+  .promo .btn {
+    padding: 12px 16px;
+    font-size: 1rem;
+  }
+}
+</style>

--- a/src/views/LiveCasinoView.vue
+++ b/src/views/LiveCasinoView.vue
@@ -56,4 +56,32 @@ import { allGames } from '@/data/mockData.js';
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
 }
+@media (max-width: 1024px) {
+  .hero {
+    height: 35vh;
+  }
+  .hero h1 {
+    font-size: 2.5rem;
+  }
+}
+@media (max-width: 768px) {
+  .hero {
+    height: 30vh;
+    padding: 0 16px;
+  }
+  .hero h1 {
+    font-size: 2rem;
+  }
+  .hero p {
+    font-size: 1rem;
+  }
+  .games-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+@media (max-width: 480px) {
+  .games-grid {
+    grid-template-columns: 1fr;
+  }
+}
 </style>

--- a/src/views/SlotsView.vue
+++ b/src/views/SlotsView.vue
@@ -53,4 +53,19 @@ const filteredGames = computed(() => {
   outline: none;
   border-color: var(--accent);
 }
+@media (max-width: 768px) {
+  .page-header h1 {
+    font-size: 2rem;
+  }
+  .search-bar input {
+    max-width: 100%;
+    padding: 14px 16px;
+  }
+}
+@media (max-width: 480px) {
+  .search-bar input {
+    padding: 16px;
+    font-size: 1.1rem;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- add mobile-friendly promo layout in home view
- adjust category, live casino, and slots views for tablet and mobile breakpoints

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acab58b7bc8320b70e3a0492f6cd02