### PR TITLE
Add localStorage auth and responsive auth views

### DIFF
--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -1,19 +1,30 @@
 <script setup>
-import { ref } from 'vue';
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import useAuth from '../composables/useAuth.js'
 
-const isMobileMenuOpen = ref(false);
+const router = useRouter()
+const { isLoggedIn, logout } = useAuth()
+
+const isMobileMenuOpen = ref(false)
 
 function toggleMobileMenu() {
-  isMobileMenuOpen.value = !isMobileMenuOpen.value;
+  isMobileMenuOpen.value = !isMobileMenuOpen.value
+}
+
+function handleLogout() {
+  logout()
+  toggleMobileMenu()
+  router.push('/')
 }
 </script>
 
 <template>
   <header class="site-header">
     <div class="container header-inner">
-      <a href="#" class="logo" aria-label="GG Casino — на главную">
+      <router-link to="/" class="logo" aria-label="GG Casino — на главную">
         <span aria-hidden="true">GG</span><span class="accent" aria-hidden="true">•</span>Casino
-      </a>
+      </router-link>
 
       <nav class="nav desktop-nav" aria-label="Основная навигация">
         <ul class="nav-list">
@@ -25,11 +36,22 @@ function toggleMobileMenu() {
       </nav>
 
       <div class="auth desktop-auth">
-        <a href="#" class="btn btn-ghost">Войти</a>
-        <a href="#" class="btn btn-ghost">Регистрация</a>
+        <template v-if="isLoggedIn">
+          <router-link to="/account" class="btn btn-ghost">Мой кабинет</router-link>
+          <button class="btn btn-ghost" @click="handleLogout">Выйти</button>
+        </template>
+        <template v-else>
+          <router-link to="/login" class="btn btn-ghost">Войти</router-link>
+          <router-link to="/register" class="btn btn-ghost">Регистрация</router-link>
+        </template>
       </div>
 
-      <button class="burger-menu" @click="toggleMobileMenu" aria-label="Открыть меню" :class="{ 'is-active': isMobileMenuOpen }">
+      <button
+        class="burger-menu"
+        @click="toggleMobileMenu"
+        aria-label="Открыть меню"
+        :class="{ 'is-active': isMobileMenuOpen }"
+      >
         <span></span>
         <span></span>
         <span></span>
@@ -37,16 +59,35 @@ function toggleMobileMenu() {
     </div>
 
     <nav class="mobile-nav" :class="{ 'is-open': isMobileMenuOpen }">
-       <ul class="nav-list">
-          <li><a href="#games" @click="toggleMobileMenu">Игры</a></li>
-          <li><a href="#bonuses" @click="toggleMobileMenu">Бонусы</a></li>
-          <li><a href="#tournaments" @click="toggleMobileMenu">Турниры</a></li>
-          <li><a href="#support" @click="toggleMobileMenu">Поддержка</a></li>
-        </ul>
-        <div class="auth">
-           <a href="#" class="btn btn-ghost">Войти</a>
-           <a href="#" class="btn">Регистрация</a>
-        </div>
+      <ul class="nav-list">
+        <li><a href="#games" @click="toggleMobileMenu">Игры</a></li>
+        <li><a href="#bonuses" @click="toggleMobileMenu">Бонусы</a></li>
+        <li><a href="#tournaments" @click="toggleMobileMenu">Турниры</a></li>
+        <li><a href="#support" @click="toggleMobileMenu">Поддержка</a></li>
+      </ul>
+      <div class="auth">
+        <template v-if="isLoggedIn">
+          <router-link to="/account" class="btn btn-ghost" @click="toggleMobileMenu">Мой кабинет</router-link>
+          <button class="btn btn-ghost" @click="handleLogout">Выйти</button>
+        </template>
+        <template v-else>
+          <router-link to="/login" class="btn btn-ghost" @click="toggleMobileMenu">Войти</router-link>
+          <router-link to="/register" class="btn" @click="toggleMobileMenu">Регистрация</router-link>
+        </template>
+      </div>
     </nav>
   </header>
 </template>
+
+<style scoped>
+/* styles remain from global stylesheet; scoped block to ensure buttons in mobile nav */
+.mobile-nav .auth {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+}
+.mobile-nav .auth .btn {
+  width: 100%;
+}
+</style>

--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -26,7 +26,7 @@ function login(credentials) {
   if (!stored) return false
   const storedUser = JSON.parse(stored)
   const valid =
-    credentials.username === storedUser.username &&
+    credentials.email === storedUser.email &&
     credentials.password === storedUser.password
   if (valid) {
     localStorage.setItem('isLoggedIn', 'true')

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,31 +1,56 @@
 <script setup>
-import LeftSidebar from '../components/LeftSidebar.vue';
-import RightSidebar from '../components/RightSidebar.vue';
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import useAuth from '../composables/useAuth.js'
+
+const router = useRouter()
+const { user, logout } = useAuth()
+
+const email = computed(() => user.value?.email || '')
+
+function handleLogout() {
+  logout()
+  router.push('/')
+}
 </script>
 
 <template>
-  <div class="main-layout container">
-    <LeftSidebar />
-    <div class="main-content">
-      <div class="page-header">
-        <h1>Аккаунт</h1>
-        <p>Управляйте данными своего профиля.</p>
-      </div>
-      <div class="account-details">
-        <p><strong>Имя пользователя:</strong> demo</p>
-        <p><strong>Email:</strong> demo@example.com</p>
-      </div>
+  <div class="account-page">
+    <div class="account-card">
+      <h1>Личный кабинет</h1>
+      <p class="email">{{ email }}</p>
+      <button class="btn logout" @click="handleLogout">Выйти</button>
     </div>
-    <RightSidebar />
   </div>
 </template>
 
 <style scoped>
-.page-header { margin-bottom: 32px; }
-.account-details {
-  background: var(--card);
-  padding: 24px;
-  border-radius: var(--radius);
+.account-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 140px);
 }
-.account-details p { margin-bottom: 8px; }
+.account-card {
+  width: 100%;
+  max-width: 640px;
+  background: #14161b;
+  padding: 32px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+.account-card h1 {
+  margin-bottom: 16px;
+  font-size: 2rem;
+}
+.email {
+  margin-bottom: 24px;
+  color: #ff9a00;
+  font-weight: 600;
+}
+.logout {
+  width: 100%;
+  padding: 14px;
+}
 </style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,53 +1,164 @@
 <script setup>
-import LeftSidebar from '../components/LeftSidebar.vue';
-import RightSidebar from '../components/RightSidebar.vue';
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import useAuth from '../composables/useAuth.js'
+
+const router = useRouter()
+const { login } = useAuth()
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+
+function onSubmit() {
+  const success = login({ email: email.value, password: password.value })
+  if (success) {
+    router.push('/account')
+  } else {
+    error.value = 'Неверный e-mail или пароль'
+  }
+}
 </script>
 
 <template>
-  <div class="main-layout container">
-    <LeftSidebar />
-    <div class="main-content">
-      <div class="auth-form">
-        <img class="auth-logo" src="/img/loginlogo.png" alt="Login" />
+  <div class="auth-container">
+    <div class="login-box">
+      <div class="login-form">
+        <router-link to="/" class="close-btn" aria-label="Закрыть">×</router-link>
         <h1>Вход</h1>
-        <form>
-          <input type="email" placeholder="Email" required />
-          <input type="password" placeholder="Пароль" required />
-          <button type="submit" class="btn btn-lg">Войти</button>
+        <form @submit.prevent="onSubmit">
+          <label for="email">E-mail</label>
+          <input type="email" id="email" v-model="email" placeholder="Введите e-mail" required />
+
+          <label for="password">Пароль</label>
+          <input type="password" id="password" v-model="password" placeholder="Введите пароль" required />
+
+          <button type="submit">Войти</button>
+          <p v-if="error" class="error">{{ error }}</p>
         </form>
-        <router-link to="/password-recovery" class="link">Забыли пароль?</router-link>
-        <router-link to="/register" class="link">Регистрация</router-link>
+        <div class="extra">
+          <p>Нет аккаунта? <router-link to="/register">Регистрация</router-link></p>
+          <p><router-link to="/password-recovery">Забыли пароль?</router-link></p>
+        </div>
       </div>
     </div>
-    <RightSidebar />
+    <div class="bonus-section">
+      <img src="/img/lodgincard.png" alt="lodgincard" />
+    </div>
   </div>
 </template>
 
 <style scoped>
-.auth-form {
-  max-width: 400px;
-  margin: 0 auto;
+.auth-container {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+}
+.login-box {
+  width: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.login-form {
+  width: 640px;
+  background: #14161b;
   padding: 32px;
-  background: var(--card);
-  border-radius: var(--radius);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+  position: relative;
+}
+.login-form h1 {
+  margin: 0 0 24px;
+  font-size: 2rem;
   text-align: center;
 }
-.auth-logo {
-  width: 120px;
-  margin: 0 auto 24px;
-}
-.auth-form input {
-  width: 100%;
-  padding: 12px 16px;
-  margin-bottom: 16px;
-  background-color: #1d1f26;
-  border: 1px solid #2a2f3a;
-  border-radius: 8px;
-  color: var(--text);
-}
-.auth-form .link {
+.login-form label {
   display: block;
+  margin-bottom: 8px;
+}
+.login-form input {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+.login-form input:focus {
+  outline: none;
+  border-color: #ff4d00;
+}
+.login-form button {
+  width: 100%;
+  padding: 14px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background .3s;
+}
+.login-form button:hover {
+  background: #ff1a1a;
+}
+.login-form .extra {
+  margin-top: 16px;
+  text-align: center;
+}
+.login-form .extra a {
+  color: #ff9a00;
+}
+.login-form .extra a:hover {
+  text-decoration: underline;
+}
+.bonus-section {
+  width: 50%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0b0c10;
+}
+.bonus-section img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.close-btn {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #f1f5f9;
+  text-decoration: none;
+  transition: color .2s;
+}
+.close-btn:hover {
+  color: #ff4d00;
+}
+.error {
+  color: #ff4d00;
   margin-top: 8px;
-  color: var(--accent);
+  text-align: center;
+}
+@media (max-width: 768px) {
+  .auth-container {
+    flex-direction: column;
+    height: auto;
+  }
+  .login-box, .bonus-section {
+    width: 100%;
+  }
+  .bonus-section {
+    height: 200px;
+  }
+  .login-form {
+    width: 100%;
+    margin: 24px;
+  }
 }
 </style>

--- a/src/views/PasswordRecoveryView.vue
+++ b/src/views/PasswordRecoveryView.vue
@@ -1,51 +1,149 @@
 <script setup>
-import LeftSidebar from '../components/LeftSidebar.vue';
-import RightSidebar from '../components/RightSidebar.vue';
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const email = ref('')
+const message = ref('')
+
+function onSubmit() {
+  message.value = 'Если такой e-mail существует, мы отправили инструкцию по восстановлению.'
+  setTimeout(() => router.push('/login'), 1000)
+}
 </script>
 
 <template>
-  <div class="main-layout container">
-    <LeftSidebar />
-    <div class="main-content">
-      <div class="auth-form">
-        <img class="auth-logo" src="/img/passrec.png" alt="Password recovery" />
+  <div class="auth-container">
+    <router-link to="/login" class="nav-btn back-btn" aria-label="Назад">‹</router-link>
+    <router-link to="/" class="nav-btn close-btn" aria-label="Закрыть">×</router-link>
+    <div class="recovery-box">
+      <div class="recovery-form">
         <h1>Восстановление пароля</h1>
-        <form>
-          <input type="email" placeholder="Email" required />
-          <button type="submit" class="btn btn-lg">Отправить ссылку</button>
+        <p>Пожалуйста, введи свои данные ниже, чтобы сбросить пароль.</p>
+        <form @submit.prevent="onSubmit">
+          <label for="email">E-mail</label>
+          <input type="email" id="email" v-model="email" placeholder="Введите e-mail" required />
+          <button type="submit">Подтвердить</button>
+          <p v-if="message" class="success">{{ message }}</p>
         </form>
-        <router-link to="/login" class="link">Назад ко входу</router-link>
       </div>
     </div>
-    <RightSidebar />
+    <div class="image-section">
+      <img src="/img/passrec.png" alt="passrec" />
+    </div>
   </div>
 </template>
 
 <style scoped>
-.auth-form {
-  max-width: 400px;
-  margin: 0 auto;
+.auth-container {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  position: relative;
+}
+.recovery-box {
+  width: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.recovery-form {
+  width: 640px;
+  background: #14161b;
   padding: 32px;
-  background: var(--card);
-  border-radius: var(--radius);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+.recovery-form h1 {
+  margin: 0 0 24px;
+  font-size: 2rem;
+}
+.recovery-form p {
+  margin: 0 0 24px;
+  color: #94a3b8;
+}
+.recovery-form label {
+  display: block;
+  margin-bottom: 8px;
+}
+.recovery-form input {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+.recovery-form input:focus {
+  outline: none;
+  border-color: #ff4d00;
+}
+.recovery-form button {
+  width: 100%;
+  padding: 14px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background .3s;
+}
+.recovery-form button:hover {
+  background: #ff1a1a;
+}
+.image-section {
+  width: 50%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0b0c10;
+}
+.image-section img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.nav-btn {
+  position: absolute;
+  top: 20px;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #f1f5f9;
+  text-decoration: none;
+  transition: color .2s;
+  padding: 8px;
+}
+.nav-btn.close-btn {
+  right: 20px;
+}
+.nav-btn.back-btn {
+  left: 20px;
+}
+.nav-btn:hover {
+  color: #ff4d00;
+}
+.success {
+  color: #ff9a00;
+  margin-top: 8px;
   text-align: center;
 }
-.auth-logo {
-  width: 120px;
-  margin: 0 auto 24px;
-}
-.auth-form input {
-  width: 100%;
-  padding: 12px 16px;
-  margin-bottom: 16px;
-  background-color: #1d1f26;
-  border: 1px solid #2a2f3a;
-  border-radius: 8px;
-  color: var(--text);
-}
-.auth-form .link {
-  display: block;
-  margin-top: 8px;
-  color: var(--accent);
+@media (max-width: 768px) {
+  .auth-container {
+    flex-direction: column;
+    height: auto;
+  }
+  .recovery-box, .image-section {
+    width: 100%;
+  }
+  .image-section {
+    height: 200px;
+  }
+  .recovery-form {
+    width: 100%;
+    margin: 24px;
+  }
 }
 </style>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -1,54 +1,178 @@
 <script setup>
-import LeftSidebar from '../components/LeftSidebar.vue';
-import RightSidebar from '../components/RightSidebar.vue';
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import useAuth from '../composables/useAuth.js'
+
+const router = useRouter()
+const { register } = useAuth()
+
+const email = ref('')
+const password = ref('')
+const message = ref('')
+
+function onSubmit() {
+  register({ email: email.value, password: password.value })
+  message.value = 'Регистрация успешна!'
+  setTimeout(() => router.push('/account'), 1000)
+}
 </script>
 
 <template>
-  <div class="main-layout container">
-    <LeftSidebar />
-    <div class="main-content">
-      <div class="auth-form">
-        <img class="auth-logo" src="/img/lodgincard.png" alt="Register" />
+  <div class="auth-container">
+    <div class="login-box">
+      <div class="login-form">
+        <router-link to="/" class="close-btn" aria-label="Закрыть">×</router-link>
         <h1>Регистрация</h1>
-        <form>
-          <input type="text" placeholder="Имя пользователя" required />
-          <input type="email" placeholder="Email" required />
-          <input type="password" placeholder="Пароль" required />
-          <input type="password" placeholder="Подтвердите пароль" required />
-          <button type="submit" class="btn btn-lg">Создать аккаунт</button>
+        <form @submit.prevent="onSubmit">
+          <label for="email">E-mail</label>
+          <input type="email" id="email" v-model="email" placeholder="Введите e-mail" required />
+
+          <label for="password">Пароль</label>
+          <input type="password" id="password" v-model="password" placeholder="Введите пароль" required />
+
+          <button type="submit">Зарегистрироваться</button>
+          <p v-if="message" class="success">{{ message }}</p>
         </form>
-        <router-link to="/login" class="link">Уже есть аккаунт? Войти</router-link>
+        <div class="extra">
+          <p>Уже есть аккаунт? <router-link to="/login">Login</router-link></p>
+        </div>
+      </div>
+      <div class="terms-text">
+        <p>
+          Я подтверждаю, что достиг(-ла) возраста 18 лет или минимально допустимого возраста для игры в азартные игры, предусмотренного законодательством страны моего проживания, являюсь дееспособным(-ой) и не имею зависимости от азартных игр. Я подтверждаю, что ознакомлен(-на), согласен(-на) и принимаю <a href="#">Условия и положения</a>. Я также ознакомлен(-на) и согласен(-на) с <a href="#">Политикой конфиденциальности</a>.
+        </p>
       </div>
     </div>
-    <RightSidebar />
+    <div class="bonus-section">
+      <img src="/img/lodgincard.png" alt="lodgincard" />
+    </div>
   </div>
 </template>
 
 <style scoped>
-.auth-form {
-  max-width: 400px;
-  margin: 0 auto;
+.auth-container {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+}
+.login-box {
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.login-form {
+  width: 640px;
+  background: #14161b;
   padding: 32px;
-  background: var(--card);
-  border-radius: var(--radius);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+  position: relative;
+}
+.login-form h1 {
+  margin: 0 0 24px;
+  font-size: 2rem;
   text-align: center;
 }
-.auth-logo {
-  width: 120px;
-  margin: 0 auto 24px;
-}
-.auth-form input {
-  width: 100%;
-  padding: 12px 16px;
-  margin-bottom: 16px;
-  background-color: #1d1f26;
-  border: 1px solid #2a2f3a;
-  border-radius: 8px;
-  color: var(--text);
-}
-.auth-form .link {
+.login-form label {
   display: block;
+  margin-bottom: 8px;
+}
+.login-form input {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+.login-form input:focus {
+  outline: none;
+  border-color: #ff4d00;
+}
+.login-form button {
+  width: 100%;
+  padding: 14px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background .3s;
+}
+.login-form button:hover {
+  background: #ff1a1a;
+}
+.login-form .extra {
+  margin-top: 16px;
+  text-align: center;
+}
+.login-form .extra a {
+  color: #ff9a00;
+}
+.login-form .extra a:hover {
+  text-decoration: underline;
+}
+.terms-text {
+  width: 640px;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: 24px;
+  line-height: 1.4;
+  text-align: center;
+}
+.terms-text a {
+  color: #ff9a00;
+  text-decoration: underline;
+}
+.bonus-section {
+  width: 50%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #0b0c10;
+}
+.bonus-section img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.close-btn {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #f1f5f9;
+  text-decoration: none;
+  transition: color .2s;
+}
+.close-btn:hover {
+  color: #ff4d00;
+}
+.success {
+  color: #ff9a00;
   margin-top: 8px;
-  color: var(--accent);
+  text-align: center;
+}
+@media (max-width: 768px) {
+  .auth-container {
+    flex-direction: column;
+    height: auto;
+  }
+  .login-box, .bonus-section {
+    width: 100%;
+  }
+  .bonus-section {
+    height: 200px;
+  }
+  .login-form, .terms-text {
+    width: 100%;
+    margin: 24px;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Implement localStorage-based auth composable and account view with logout
- Add login, registration and password recovery pages with mobile-friendly styling
- Update header to show cabinet and logout when logged in

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acaaf14e8c832082ec2b060e68eb3b