### PR TITLE
feat: enhance account dashboard

### DIFF
--- a/src/components/account/AccountBonuses.vue
+++ b/src/components/account/AccountBonuses.vue
@@ -1,0 +1,55 @@
+<script setup>
+const bonuses = [
+  { title: 'Приветственный бонус', description: '100% на первый депозит', active: true },
+  { title: 'Кешбэк', description: '10% каждую неделю', active: false }
+]
+</script>
+
+<template>
+  <div class="bonuses">
+    <h2>Бонусы</h2>
+    <div class="bonus-list">
+      <div v-for="(b, i) in bonuses" :key="i" class="bonus-card" :class="{ inactive: !b.active }">
+        <h3>{{ b.title }}</h3>
+        <p>{{ b.description }}</p>
+        <span v-if="b.active" class="status active">Активен</span>
+        <span v-else class="status">Неактивен</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bonus-list {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.bonus-card {
+  width: 260px;
+  background: #14161b;
+  padding: 20px;
+  border-radius: 12px;
+  position: relative;
+}
+.bonus-card.inactive {
+  opacity: .6;
+}
+.bonus-card h3 {
+  margin-bottom: 8px;
+}
+.status {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: #1e232d;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+.status.active {
+  background: #ff4d00;
+  color: #fff;
+}
+</style>

--- a/src/components/account/AccountOverview.vue
+++ b/src/components/account/AccountOverview.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { ref } from 'vue'
+import useAuth from '../../composables/useAuth.js'
+
+const { balance, deposit, withdraw } = useAuth()
+
+const depositAmount = ref('')
+const withdrawAmount = ref('')
+const message = ref('')
+
+function handleDeposit() {
+  if (deposit(depositAmount.value)) {
+    message.value = 'Баланс пополнен'
+    depositAmount.value = ''
+  } else {
+    message.value = 'Некорректная сумма'
+  }
+}
+
+function handleWithdraw() {
+  if (withdraw(withdrawAmount.value)) {
+    message.value = 'Вывод выполнен'
+    withdrawAmount.value = ''
+  } else {
+    message.value = 'Недостаточно средств'
+  }
+}
+</script>
+
+<template>
+  <div class="overview">
+    <h2>Баланс: <span>{{ balance.toFixed(2) }}₴</span></h2>
+    <div class="actions">
+      <form @submit.prevent="handleDeposit" class="action">
+        <label>Сумма пополнения</label>
+        <input v-model.number="depositAmount" type="number" min="1" required />
+        <button type="submit">Пополнить</button>
+      </form>
+      <form @submit.prevent="handleWithdraw" class="action">
+        <label>Сумма вывода</label>
+        <input v-model.number="withdrawAmount" type="number" min="1" required />
+        <button type="submit">Вывести</button>
+      </form>
+    </div>
+    <p v-if="message" class="message">{{ message }}</p>
+  </div>
+</template>
+
+<style scoped>
+.overview {
+  max-width: 600px;
+}
+h2 {
+  margin-bottom: 24px;
+}
+h2 span {
+  color: #ff9a00;
+}
+.actions {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.action {
+  flex: 1;
+  background: #14161b;
+  padding: 20px;
+  border-radius: 12px;
+}
+.action label {
+  display: block;
+  margin-bottom: 8px;
+}
+.action input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 12px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+.action button {
+  width: 100%;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background .3s;
+}
+.action button:hover {
+  background: #ff1a1a;
+}
+.message {
+  margin-top: 16px;
+  color: #ff9a00;
+}
+</style>

--- a/src/components/account/AccountSettings.vue
+++ b/src/components/account/AccountSettings.vue
@@ -1,0 +1,75 @@
+<script setup>
+import { ref } from 'vue'
+import useAuth from '../../composables/useAuth.js'
+
+const { user } = useAuth()
+const email = ref(user.value?.email || '')
+const password = ref('')
+const message = ref('')
+
+function save() {
+  const updated = { ...user.value, email: email.value }
+  if (password.value) {
+    updated.password = password.value
+  }
+  localStorage.setItem('authUser', JSON.stringify(updated))
+  user.value = updated
+  message.value = 'Данные обновлены'
+  password.value = ''
+}
+</script>
+
+<template>
+  <div class="settings">
+    <h2>Настройки профиля</h2>
+    <form @submit.prevent="save" class="settings-form">
+      <label>E-mail</label>
+      <input v-model="email" type="email" required />
+      <label>Новый пароль</label>
+      <input v-model="password" type="password" placeholder="Оставьте пустым, чтобы не менять" />
+      <button type="submit">Сохранить</button>
+      <p v-if="message" class="message">{{ message }}</p>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.settings {
+  max-width: 600px;
+}
+.settings-form {
+  background: #14161b;
+  padding: 20px;
+  border-radius: 12px;
+}
+.settings-form label {
+  display: block;
+  margin-bottom: 8px;
+}
+.settings-form input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+.settings-form button {
+  width: 100%;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background .3s;
+}
+.settings-form button:hover {
+  background: #ff1a1a;
+}
+.message {
+  margin-top: 12px;
+  color: #ff9a00;
+}
+</style>

--- a/src/components/account/AccountSidebar.vue
+++ b/src/components/account/AccountSidebar.vue
@@ -1,0 +1,85 @@
+<script setup>
+const props = defineProps({
+  active: { type: String, default: 'overview' },
+  email: { type: String, default: '' }
+})
+const emit = defineEmits(['change', 'logout'])
+
+const links = [
+  { id: 'overview', label: 'Обзор' },
+  { id: 'transactions', label: 'Транзакции' },
+  { id: 'bonuses', label: 'Бонусы' },
+  { id: 'settings', label: 'Настройки' }
+]
+</script>
+
+<template>
+  <aside class="sidebar">
+    <div class="profile">
+      <p class="email">{{ email }}</p>
+    </div>
+    <nav>
+      <ul>
+        <li v-for="l in links" :key="l.id">
+          <button :class="{ active: l.id === active }" @click="$emit('change', l.id)">
+            {{ l.label }}
+          </button>
+        </li>
+      </ul>
+    </nav>
+    <button class="logout" @click="$emit('logout')">Выйти</button>
+  </aside>
+</template>
+
+<style scoped>
+.sidebar {
+  width: 240px;
+  background: #14161b;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+}
+.profile {
+  margin-bottom: 24px;
+}
+.email {
+  color: #ff9a00;
+  font-weight: 600;
+}
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px 0;
+}
+nav li {
+  margin-bottom: 8px;
+}
+nav button {
+  width: 100%;
+  padding: 12px 16px;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: #f1f5f9;
+  cursor: pointer;
+  transition: background .3s;
+}
+nav button:hover,
+nav button.active {
+  background: #1e232d;
+}
+.logout {
+  margin-top: auto;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background .3s;
+}
+.logout:hover {
+  background: #ff1a1a;
+}
+</style>

--- a/src/components/account/AccountTransactions.vue
+++ b/src/components/account/AccountTransactions.vue
@@ -1,0 +1,56 @@
+<script setup>
+import useAuth from '../../composables/useAuth.js'
+
+const { transactions } = useAuth()
+</script>
+
+<template>
+  <div class="transactions">
+    <h2>История транзакций</h2>
+    <table v-if="transactions.length">
+      <thead>
+        <tr>
+          <th>Дата</th>
+          <th>Тип</th>
+          <th>Сумма</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(t, i) in transactions" :key="i">
+          <td>{{ new Date(t.date).toLocaleString() }}</td>
+          <td>{{ t.type === 'deposit' ? 'Пополнение' : 'Вывод' }}</td>
+          <td :class="{ negative: t.type === 'withdraw' }">
+            {{ t.type === 'withdraw' ? '-' : '+' }}{{ t.amount.toFixed(2) }}₴
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else>Транзакций пока нет.</p>
+  </div>
+</template>
+
+<style scoped>
+.transactions {
+  max-width: 800px;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #14161b;
+  border-radius: 12px;
+  overflow: hidden;
+}
+th, td {
+  padding: 12px 16px;
+  text-align: left;
+}
+th {
+  background: #1e232d;
+}
+tbody tr:nth-child(even) {
+  background: #1a1d23;
+}
+.negative {
+  color: #ff4d00;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,12 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import GameCategoryView from '../views/GameCategoryView.vue'
-import DropsAndWinsView from '../views/DropsAndWinsView.vue';
-import LoginView from '../views/LoginView.vue';
-import RegisterView from '../views/RegisterView.vue';
-import PasswordRecoveryView from '../views/PasswordRecoveryView.vue';
-import DepositView from '../views/DepositView.vue';
-import { allGames, rouletteGames, newGames } from '@/data/mockData.js'; // Імпортуємо новий масив
+import DropsAndWinsView from '../views/DropsAndWinsView.vue'
+import LoginView from '../views/LoginView.vue'
+import RegisterView from '../views/RegisterView.vue'
+import PasswordRecoveryView from '../views/PasswordRecoveryView.vue'
+import DepositView from '../views/DepositView.vue'
+import AccountView from '../views/AccountView.vue'
+import useAuth from '../composables/useAuth.js'
+import { allGames, rouletteGames, newGames } from '@/data/mockData.js'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -14,63 +16,29 @@ const router = createRouter({
     return { top: 0 }
   },
   routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: HomeView
-    },
-    {
-      path: '/popular',
-      redirect: '/'
-    },
-    {
-      path: '/slots',
-      name: 'slots',
-      component: () => import('../views/SlotsView.vue')
-    },
-    {
-      path: '/live-casino',
-      name: 'live-casino',
-      component: () => import('../views/LiveCasinoView.vue')
-    },
-    {
-      path: '/new',
-      name: 'new',
-      component: GameCategoryView,
-      props: { title: 'Новинки', description: 'Новейшие игры от ведущих провайдеров.', games: newGames }
-    },
-    {
-      path: '/drops-wins',
-      name: 'drops-wins',
-      component: DropsAndWinsView
-    },
-    {
-      path: '/roulette',
-      name: 'roulette',
-      component: GameCategoryView,
-      props: { title: 'Рулетка', description: 'Все виды рулетки: европейская, американская и другие.', games: rouletteGames }
-    },
-    {
-      path: '/login',
-      name: 'login',
-      component: LoginView
-    },
-    {
-      path: '/register',
-      name: 'register',
-      component: RegisterView
-    },
-    {
-      path: '/password-recovery',
-      name: 'password-recovery',
-      component: PasswordRecoveryView
-    },
-    {
-      path: '/deposit',
-      name: 'deposit',
-      component: DepositView
-    }
+    { path: '/', name: 'home', component: HomeView },
+    { path: '/popular', redirect: '/' },
+    { path: '/slots', name: 'slots', component: () => import('../views/SlotsView.vue') },
+    { path: '/live-casino', name: 'live-casino', component: () => import('../views/LiveCasinoView.vue') },
+    { path: '/new', name: 'new', component: GameCategoryView, props: { title: 'Новинки', description: 'Новейшие игры от ведущих провайдеров.', games: newGames } },
+    { path: '/drops-wins', name: 'drops-wins', component: DropsAndWinsView },
+    { path: '/roulette', name: 'roulette', component: GameCategoryView, props: { title: 'Рулетка', description: 'Все виды рулетки: европейская, американская и другие.', games: rouletteGames } },
+    { path: '/login', name: 'login', component: LoginView },
+    { path: '/register', name: 'register', component: RegisterView },
+    { path: '/password-recovery', name: 'password-recovery', component: PasswordRecoveryView },
+    { path: '/deposit', name: 'deposit', component: DepositView },
+    { path: '/account', name: 'account', component: AccountView, meta: { requiresAuth: true } }
   ]
+})
+
+const { isLoggedIn } = useAuth()
+
+router.beforeEach((to, from, next) => {
+  if (to.meta.requiresAuth && !isLoggedIn.value) {
+    next({ name: 'login', query: { redirect: to.fullPath } })
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,12 +1,25 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import useAuth from '../composables/useAuth.js'
+import AccountSidebar from '../components/account/AccountSidebar.vue'
+import AccountOverview from '../components/account/AccountOverview.vue'
+import AccountTransactions from '../components/account/AccountTransactions.vue'
+import AccountBonuses from '../components/account/AccountBonuses.vue'
+import AccountSettings from '../components/account/AccountSettings.vue'
 
 const router = useRouter()
 const { user, logout } = useAuth()
 
 const email = computed(() => user.value?.email || '')
+const activeTab = ref('overview')
+
+const components = {
+  overview: AccountOverview,
+  transactions: AccountTransactions,
+  bonuses: AccountBonuses,
+  settings: AccountSettings
+}
 
 function handleLogout() {
   logout()
@@ -16,10 +29,9 @@ function handleLogout() {
 
 <template>
   <div class="account-page">
-    <div class="account-card">
-      <h1>Личный кабинет</h1>
-      <p class="email">{{ email }}</p>
-      <button class="btn logout" @click="handleLogout">Выйти</button>
+    <AccountSidebar :active="activeTab" :email="email" @change="tab => activeTab = tab" @logout="handleLogout" />
+    <div class="account-content">
+      <component :is="components[activeTab]" />
     </div>
   </div>
 </template>
@@ -27,30 +39,10 @@ function handleLogout() {
 <style scoped>
 .account-page {
   display: flex;
-  justify-content: center;
-  align-items: center;
   min-height: calc(100vh - 140px);
 }
-.account-card {
-  width: 100%;
-  max-width: 640px;
-  background: #14161b;
-  padding: 32px;
-  border-radius: 12px;
-  text-align: center;
-  box-shadow: 0 10px 30px rgba(0,0,0,.35);
-}
-.account-card h1 {
-  margin-bottom: 16px;
-  font-size: 2rem;
-}
-.email {
-  margin-bottom: 24px;
-  color: #ff9a00;
-  font-weight: 600;
-}
-.logout {
-  width: 100%;
-  padding: 14px;
+.account-content {
+  flex: 1;
+  padding: 24px;
 }
 </style>


### PR DESCRIPTION
## Summary
- add sidebar-driven account dashboard with sections for overview, transactions, bonuses, and settings
- enable balance management with deposit/withdraw and persistent transaction history
- protect account route with auth guard and track balance/transactions in storage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b3228c00c08320ac8db180573026b0