### PR TITLE
feat: add russian personal cabinet sections

### DIFF
--- a/src/components/account/AccountDocuments.vue
+++ b/src/components/account/AccountDocuments.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref } from 'vue'
+
+const file = ref(null)
+const dragging = ref(false)
+
+function onDrop(e) {
+  e.preventDefault()
+  dragging.value = false
+  if (e.dataTransfer.files.length) {
+    file.value = e.dataTransfer.files[0]
+  }
+}
+
+function onChange(e) {
+  file.value = e.target.files[0]
+}
+
+function upload() {
+  if (file.value) {
+    localStorage.setItem('uploadedDocument', file.value.name)
+    alert('Документ загружен')
+    file.value = null
+  }
+}
+</script>
+
+<template>
+  <div class="documents">
+    <div
+      class="drop-area"
+      :class="{ over: dragging }"
+      @dragover.prevent="dragging = true"
+      @dragleave.prevent="dragging = false"
+      @drop="onDrop"
+    >
+      <input id="fileInput" type="file" class="hidden" @change="onChange" />
+      <label for="fileInput">
+        <span v-if="!file">Перетащите файл или нажмите для выбора</span>
+        <span v-else>{{ file.name }}</span>
+      </label>
+    </div>
+    <button @click="upload" :disabled="!file">Загрузить</button>
+  </div>
+</template>
+
+<style scoped>
+.documents {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.drop-area {
+  border: 2px dashed #2a2f3a;
+  padding: 40px;
+  text-align: center;
+  margin-bottom: 16px;
+  cursor: pointer;
+  width: 100%;
+  border-radius: 12px;
+  background: #14161b;
+  transition: border-color 0.3s;
+}
+
+.drop-area.over {
+  border-color: #ff4d00;
+}
+
+.hidden {
+  display: none;
+}
+
+button {
+  padding: 12px 24px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+  width: 100%;
+}
+
+button:hover {
+  background: #ff1a1a;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+@media (max-width: 480px) {
+  .drop-area {
+    padding: 24px;
+  }
+}
+</style>

--- a/src/components/account/AccountLimits.vue
+++ b/src/components/account/AccountLimits.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { reactive, ref, onMounted } from 'vue'
+
+const form = reactive({
+  moneyPeriod: 'day',
+  moneyAmount: 'Максимальный',
+  dailyTime: 'Максимальный',
+  weeklyTime: 'Максимальный'
+})
+
+const message = ref('')
+
+onMounted(() => {
+  const saved = JSON.parse(localStorage.getItem('limits') || '{}')
+  Object.assign(form, saved)
+})
+
+function save() {
+  localStorage.setItem('limits', JSON.stringify(form))
+  message.value = 'Лимиты сохранены'
+}
+</script>
+
+<template>
+  <form class="limits" @submit.prevent="save">
+    <div class="block">
+      <h3>Лимит средств, которые игрок желает тратить</h3>
+      <div class="row">
+        <label><input type="radio" value="day" v-model="form.moneyPeriod" /> На день</label>
+        <label><input type="radio" value="week" v-model="form.moneyPeriod" /> На неделю</label>
+        <label><input type="radio" value="month" v-model="form.moneyPeriod" /> На месяц</label>
+      </div>
+      <select v-model="form.moneyAmount">
+        <option>Максимальный</option>
+        <option>1000</option>
+        <option>5000</option>
+        <option>10000</option>
+      </select>
+    </div>
+
+    <div class="block">
+      <h3>Лимит времени участия в азартных играх в сутки</h3>
+      <select v-model="form.dailyTime">
+        <option>Максимальный</option>
+        <option>1 час</option>
+        <option>2 часа</option>
+        <option>3 часа</option>
+      </select>
+    </div>
+
+    <div class="block">
+      <h3>Лимит времени участия в азартных играх в неделю</h3>
+      <select v-model="form.weeklyTime">
+        <option>Максимальный</option>
+        <option>5 часов</option>
+        <option>10 часов</option>
+        <option>20 часов</option>
+      </select>
+    </div>
+
+    <button type="submit">Сохранить</button>
+    <p v-if="message" class="message">{{ message }}</p>
+  </form>
+</template>
+
+<style scoped>
+.limits {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.block {
+  background: #14161b;
+  padding: 20px;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.5);
+}
+
+.row {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+select {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: #ff1a1a;
+}
+
+.message {
+  margin-top: 12px;
+  color: #ff9a00;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .row {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/components/account/AccountPassword.vue
+++ b/src/components/account/AccountPassword.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const password = ref('')
+const message = ref('')
+
+onMounted(() => {
+  password.value = localStorage.getItem('accountPassword') || ''
+})
+
+function save() {
+  localStorage.setItem('accountPassword', password.value)
+  message.value = 'Пароль сохранен'
+}
+</script>
+
+<template>
+  <form class="password-form" @submit.prevent="save">
+    <label>Новый пароль</label>
+    <input type="password" v-model="password" required />
+    <button type="submit">Сохранить</button>
+    <p v-if="message" class="message">{{ message }}</p>
+  </form>
+</template>
+
+<style scoped>
+.password-form {
+  max-width: 400px;
+  background: #14161b;
+  padding: 20px;
+  border-radius: 12px;
+  margin: 0 auto;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+}
+
+.password-form label {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.password-form input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+
+.password-form button {
+  width: 100%;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.password-form button:hover {
+  background: #ff1a1a;
+}
+
+.message {
+  margin-top: 12px;
+  color: #ff9a00;
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .password-form {
+    padding: 16px;
+  }
+}
+</style>

--- a/src/components/account/AccountPersonal.vue
+++ b/src/components/account/AccountPersonal.vue
@@ -1,0 +1,217 @@
+<script setup>
+import { reactive, ref, onMounted } from 'vue'
+
+const form = reactive({
+  lastName: '',
+  firstName: '',
+  middleName: '',
+  birthDate: '',
+  taxId: '',
+  country: '',
+  region: '',
+  city: '',
+  address: '',
+  postalCode: '',
+  email: '',
+  phone: ''
+})
+
+const message = ref('')
+const avatar = ref('')
+
+onMounted(() => {
+  const saved = JSON.parse(localStorage.getItem('personalInfo') || '{}')
+  Object.assign(form, saved)
+  avatar.value = localStorage.getItem('avatar') || ''
+})
+
+function save() {
+  localStorage.setItem('personalInfo', JSON.stringify(form))
+  message.value = 'Данные сохранены'
+}
+
+function onAvatarChange(e) {
+  const file = e.target.files[0]
+  if (file) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      avatar.value = reader.result
+      localStorage.setItem('avatar', avatar.value)
+    }
+    reader.readAsDataURL(file)
+  }
+}
+</script>
+
+<template>
+  <form class="personal-form" @submit.prevent="save">
+    <div class="avatar-upload">
+      <img v-if="avatar" :src="avatar" alt="Аватар" class="avatar" />
+      <label class="upload-label">
+        Загрузить фото профиля
+        <input type="file" accept="image/*" @change="onAvatarChange" />
+      </label>
+    </div>
+
+    <h2>Личная информация</h2>
+    <div class="grid">
+      <label>
+        Фамилия
+        <input v-model="form.lastName" required />
+      </label>
+      <label>
+        Имя
+        <input v-model="form.firstName" required />
+      </label>
+      <label>
+        Отчество
+        <input v-model="form.middleName" />
+      </label>
+      <label>
+        Дата рождения
+        <input v-model="form.birthDate" type="date" required />
+      </label>
+      <label>
+        ИНН
+        <input v-model="form.taxId" />
+      </label>
+    </div>
+
+    <h2>Адрес проживания</h2>
+    <div class="grid">
+      <label>
+        Страна
+        <input v-model="form.country" />
+      </label>
+      <label>
+        Регион
+        <input v-model="form.region" />
+      </label>
+      <label>
+        Город
+        <input v-model="form.city" />
+      </label>
+      <label>
+        Адрес
+        <input v-model="form.address" />
+      </label>
+      <label>
+        Почтовый индекс
+        <input v-model="form.postalCode" />
+      </label>
+    </div>
+
+    <h2>Контакты</h2>
+    <div class="grid">
+      <label>
+        E-mail
+        <input v-model="form.email" type="email" />
+      </label>
+      <label>
+        Телефон
+        <input v-model="form.phone" />
+      </label>
+    </div>
+
+    <button type="submit">Сохранить</button>
+    <p v-if="message" class="message">{{ message }}</p>
+  </form>
+</template>
+
+<style scoped>
+.personal-form {
+  background: #14161b;
+  padding: 24px;
+  border-radius: 12px;
+  max-width: 800px;
+  margin: 0 auto;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+}
+
+.avatar-upload {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 12px;
+}
+
+.upload-label {
+  cursor: pointer;
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: #1e232d;
+  color: #f1f5f9;
+}
+
+.upload-label input {
+  display: none;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 8px;
+}
+
+input {
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #2a2f3a;
+  background: #0b0c10;
+  color: #f1f5f9;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: #ff4d00;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: #ff1a1a;
+}
+
+.message {
+  margin-top: 12px;
+  color: #ff9a00;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .personal-form {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 481px) and (max-width: 900px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -1,35 +1,40 @@
 <script setup>
-import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
-import useAuth from '../composables/useAuth.js'
-import AccountSidebar from '../components/account/AccountSidebar.vue'
-import AccountOverview from '../components/account/AccountOverview.vue'
-import AccountTransactions from '../components/account/AccountTransactions.vue'
-import AccountBonuses from '../components/account/AccountBonuses.vue'
-import AccountSettings from '../components/account/AccountSettings.vue'
+import { ref } from 'vue'
 
-const router = useRouter()
-const { user, logout } = useAuth()
+import AccountPersonal from '../components/account/AccountPersonal.vue'
+import AccountDocuments from '../components/account/AccountDocuments.vue'
+import AccountPassword from '../components/account/AccountPassword.vue'
+import AccountLimits from '../components/account/AccountLimits.vue'
 
-const email = computed(() => user.value?.email || '')
-const activeTab = ref('overview')
+const tabs = [
+  { id: 'personal', label: 'Личный кабинет' },
+  { id: 'documents', label: 'Документы' },
+  { id: 'password', label: 'Смена пароля' },
+  { id: 'limits', label: 'Лимиты' }
+]
+
+const activeTab = ref('personal')
 
 const components = {
-  overview: AccountOverview,
-  transactions: AccountTransactions,
-  bonuses: AccountBonuses,
-  settings: AccountSettings
-}
-
-function handleLogout() {
-  logout()
-  router.push('/')
+  personal: AccountPersonal,
+  documents: AccountDocuments,
+  password: AccountPassword,
+  limits: AccountLimits
 }
 </script>
 
 <template>
   <div class="account-page">
-    <AccountSidebar :active="activeTab" :email="email" @change="tab => activeTab = tab" @logout="handleLogout" />
+    <nav class="tabs">
+      <button
+        v-for="t in tabs"
+        :key="t.id"
+        :class="{ active: activeTab === t.id }"
+        @click="activeTab = t.id"
+      >
+        {{ t.label }}
+      </button>
+    </nav>
     <div class="account-content">
       <component :is="components[activeTab]" />
     </div>
@@ -38,11 +43,52 @@ function handleLogout() {
 
 <style scoped>
 .account-page {
-  display: flex;
-  min-height: calc(100vh - 140px);
-}
-.account-content {
-  flex: 1;
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.tabs button {
+  padding: 12px 20px;
+  background: #1e232d;
+  color: #f1f5f9;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.tabs button.active {
+  background: #ff4d00;
+  color: #fff;
+}
+
+.account-content {
+  max-width: 960px;
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .account-page {
+    padding: 16px;
+  }
+
+  .tabs {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .tabs button {
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Center personal cabinet tabs and forms, add responsive styles for mobile/tablet/desktop
- Introduce profile photo upload in personal info with localStorage persistence
- Polish document upload, password change, and limits sections with improved styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b32669b2fc8320b84f23c7e7ffbe8a