### PR TITLE
Add footer pages for games, tournaments and support

### DIFF
--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -4,16 +4,16 @@
       <nav aria-label="Навигация подвала">
         <h3 class="footer-title">Разделы</h3>
         <ul class="footer-links">
-          <li><a href="#games">Игры</a></li>
-          <li><a href="#bonuses">Бонусы</a></li>
-          <li><a href="#tournaments">Турниры</a></li>
+          <li><RouterLink to="/games">Игры</RouterLink></li>
+          <li><RouterLink to="/bonuses">Бонусы</RouterLink></li>
+          <li><RouterLink to="/tournaments">Турниры</RouterLink></li>
           <li><a href="#learn-more">О нас</a></li>
         </ul>
       </nav>
       <div>
         <h3 class="footer-title">Поддержка</h3>
         <ul class="footer-links">
-          <li><a href="#">Центр помощи</a></li>
+          <li><RouterLink to="/support">Центр помощи</RouterLink></li>
           <li><RouterLink to="/terms">Правила и условия</RouterLink></li>
           <li><RouterLink to="/privacy">Политика конфиденциальности</RouterLink></li>
         </ul>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,7 +7,7 @@ import RegisterView from '../views/RegisterView.vue';
 import PasswordRecoveryView from '../views/PasswordRecoveryView.vue';
 import DepositView from '../views/DepositView.vue';
 import BonusView from '../views/BonusView.vue';
-import { allGames, rouletteGames, newGames } from '@/data/mockData.js';
+import { rouletteGames, newGames } from '@/data/mockData.js';
 import AccountView from '../views/AccountView.vue'
 
 const router = createRouter({
@@ -56,6 +56,21 @@ const router = createRouter({
       path: '/bonuses',
       name: 'bonuses',
       component: BonusView
+    },
+    {
+      path: '/games',
+      name: 'games',
+      component: () => import('../views/GamesView.vue')
+    },
+    {
+      path: '/tournaments',
+      name: 'tournaments',
+      component: () => import('../views/TournamentsView.vue')
+    },
+    {
+      path: '/support',
+      name: 'support',
+      component: () => import('../views/SupportView.vue')
     },
     {
       path: '/login',

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { ref, computed } from 'vue';
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+import GamesGrid from '../components/GamesGrid.vue';
+import { allGames, popularGames, LiveGames, rouletteGames, newGames } from '@/data/mockData.js';
+
+const tabs = [
+  { key: 'all', label: 'Все', games: allGames },
+  { key: 'popular', label: 'Популярные', games: popularGames },
+  { key: 'live', label: 'Live', games: LiveGames },
+  { key: 'roulette', label: 'Рулетка', games: rouletteGames },
+  { key: 'new', label: 'Новинки', games: newGames }
+];
+
+const activeTab = ref(tabs[0].key);
+const searchQuery = ref('');
+
+const filteredGames = computed(() => {
+  const current = tabs.find(tab => tab.key === activeTab.value);
+  if (!current) return [];
+  return current.games.filter(game =>
+    game.title.toLowerCase().includes(searchQuery.value.toLowerCase())
+  );
+});
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="page-header">
+        <h1>Игры</h1>
+        <div class="tabs">
+          <button
+            v-for="tab in tabs"
+            :key="tab.key"
+            :class="['tab-button', { active: tab.key === activeTab }]"
+            @click="activeTab = tab.key"
+          >
+            {{ tab.label }}
+          </button>
+        </div>
+        <div class="search-bar">
+          <input type="text" v-model="searchQuery" placeholder="Поиск игр..." />
+        </div>
+      </div>
+      <GamesGrid :games="filteredGames" />
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.page-header { margin-bottom: 32px; }
+.page-header h1 { font-size: 2.5rem; margin-bottom: 8px; }
+.tabs { display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap; }
+.tab-button {
+  padding: 8px 16px;
+  background-color: var(--card);
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+.tab-button.active {
+  background-color: var(--accent);
+  color: #fff;
+}
+.search-bar { margin-top: 16px; }
+.search-bar input {
+  width: 100%;
+  max-width: 400px;
+  padding: 12px 16px;
+  background-color: var(--card);
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+.search-bar input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+@media (max-width: 768px) {
+  .page-header h1 { font-size: 2rem; }
+  .search-bar input { max-width: 100%; padding: 14px 16px; }
+}
+@media (max-width: 480px) {
+  .search-bar input { padding: 16px; font-size: 1.1rem; }
+}
+</style>

--- a/src/views/SupportView.vue
+++ b/src/views/SupportView.vue
@@ -1,0 +1,33 @@
+<script setup>
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="page-header">
+        <h1>Поддержка</h1>
+        <p>Мы всегда готовы помочь вам.</p>
+      </div>
+      <div class="support-content">
+        <p>Здесь появится информация о службе поддержки.</p>
+      </div>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.page-header { margin-bottom: 32px; }
+.page-header h1 { font-size: 2.5rem; margin-bottom: 8px; }
+.support-content {
+  background-color: var(--card);
+  padding: 24px;
+  border-radius: var(--radius);
+}
+@media (max-width: 768px) {
+  .page-header h1 { font-size: 2rem; }
+}
+</style>

--- a/src/views/TournamentsView.vue
+++ b/src/views/TournamentsView.vue
@@ -1,0 +1,93 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import LeftSidebar from '../components/LeftSidebar.vue';
+import RightSidebar from '../components/RightSidebar.vue';
+
+const tournaments = ref([
+  { id: 1, name: 'Poker Masters', game: 'Poker', date: '2025-06-01' },
+  { id: 2, name: 'Holdem Championship', game: 'Poker', date: '2025-07-15' },
+  { id: 3, name: 'Omaha Cup', game: 'Poker', date: '2025-08-10' },
+  { id: 4, name: 'Speed Poker Open', game: 'Poker', date: '2025-09-05' }
+]);
+
+const searchQuery = ref('');
+const filteredTournaments = computed(() =>
+  tournaments.value.filter(t =>
+    t.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+  )
+);
+
+const participantCount = ref(1000);
+let intervalId;
+
+onMounted(() => {
+  intervalId = setInterval(() => {
+    const increments = [1, 5, 4, 8, 9];
+    const random = increments[Math.floor(Math.random() * increments.length)];
+    participantCount.value += random;
+  }, 1000);
+});
+
+onUnmounted(() => {
+  clearInterval(intervalId);
+});
+</script>
+
+<template>
+  <div class="main-layout container">
+    <LeftSidebar />
+    <div class="main-content">
+      <div class="page-header">
+        <h1>Турниры</h1>
+        <p>Покерные соревнования для всех игроков.</p>
+        <div class="search-bar">
+          <input type="text" v-model="searchQuery" placeholder="Поиск турниров..." />
+        </div>
+        <div class="counter">Участников: {{ participantCount }}</div>
+      </div>
+      <ul class="tournament-list">
+        <li v-for="t in filteredTournaments" :key="t.id" class="tournament-card">
+          <h3>{{ t.name }}</h3>
+          <p>Игра: {{ t.game }}</p>
+          <p>Дата: {{ t.date }}</p>
+        </li>
+      </ul>
+    </div>
+    <RightSidebar />
+  </div>
+</template>
+
+<style scoped>
+.page-header { margin-bottom: 32px; }
+.page-header h1 { font-size: 2.5rem; margin-bottom: 8px; }
+.search-bar { margin-top: 16px; }
+.search-bar input {
+  width: 100%;
+  max-width: 400px;
+  padding: 12px 16px;
+  background-color: var(--card);
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+.search-bar input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.counter { margin-top: 16px; font-weight: bold; }
+.tournament-list { display: grid; gap: 16px; margin-top: 24px; }
+.tournament-card {
+  background-color: var(--card);
+  padding: 16px;
+  border-radius: var(--radius);
+}
+@media (max-width: 768px) {
+  .page-header h1 { font-size: 2rem; }
+  .search-bar input { max-width: 100%; padding: 14px 16px; }
+}
+@media (max-width: 480px) {
+  .search-bar input { padding: 16px; font-size: 1.1rem; }
+}
+</style>


### PR DESCRIPTION
## Summary
- add dedicated pages and routes for games, tournaments and support
- implement tabbed game catalog with search per category
- include tournament search and live participant counter
- update footer links to point to new sections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9fac2708320a2f4ead7d4e9f31f